### PR TITLE
Add Button and Text styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The design system in the kit includes the basics:
 
 - Colors (Light+Dark Mode)
 - Icons
+- Button styles (SwiftUI, Light+Dark Mode)
+- Text styles (SwiftUI, Light+Dark Mode)
 
 Example code implementations via Swift Previews:
 - General UI elements (buttons, toggles...)
@@ -118,6 +120,44 @@ let image = BitcoinUIImage(named: "coldcard")
 let imageView = UIImageView(image: image)
 imageView.frame = CGRect(x: 0, y: 0, width: 75, height: 75)
 view.addSubview(imageView)
+```
+
+### Button Styles
+
+Three button styles are implemented in SwiftUI; BitcoinFilled, BitcoinOutlined and BitcoinPlain.
+They have a number of optional parameters, including: width, height, cornerRadius, tintColor, textColor, disabledFillColor and disabledTextColor depending on the type.
+
+SwiftUI
+
+```swift
+Button("Filled button") {
+    print("Button pressed!")
+}
+.buttonStyle(BitcoinFilled())
+
+Button("Outlined button") {
+    print("Button pressed!")
+}
+.buttonStyle(BitcoinOutlined())
+
+Button("Plain button") {
+    print("Button pressed!")
+}
+.buttonStyle(BitcoinPlain())
+```
+
+### Text Styles
+
+Ten text styles are implemented in SwiftUI; BitcoinTitle1 - BitcoinTitle5 and BitcoinBody1 - BitcoinBody5
+
+SwiftUI
+
+```swift
+Text("Title")
+    .textStyle(BitcoinTitle1())
+
+Text("Body")
+    .textStyle(BitcoinBody1())
 ```
 
 ## Requirements

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -87,8 +87,8 @@ public struct BitcoinFilled: ButtonStyle {
 /// - Parameter width: The width of the button (optional, default is 315.0)
 /// - Parameter height: The width of the button (optional, default is 48.0)
 /// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
-/// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
-/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
+/// - Parameter tintColor: The border and text color of the button (optional, default is .bitcoinOrange)
+/// - Parameter disabledColor: The disabled color of the button (optional, default is .bitcoinNeutral4)
 ///
 public struct BitcoinOutlined: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
@@ -119,6 +119,56 @@ public struct BitcoinOutlined: ButtonStyle {
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
                 )
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+    private func stateBackgroundColor() -> Color {
+        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
+    }
+    private func stateBorderColor(configuration: Configuration) -> Color {
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+    }
+    private func stateTextColor() -> Color {
+        return isEnabled ? tintColor : disabledColor
+    }
+}
+
+/// A `ButtonStyle` corresponding to the Plain type in the Bitcoin Wallet UI Kit
+///
+/// ```swift
+/// Button("Label") {
+///     print("Button pressed!")
+/// }
+///.buttonStyle(BitcoinPlain())
+/// ```
+/// - Parameter width: The width of the button (optional, default is 315.0)
+/// - Parameter height: The width of the button (optional, default is 48.0)
+/// - Parameter tintColor: The text color of the button (optional, default is .bitcoinOrange)
+/// - Parameter disabledColor: The disabled text color of the button (optional, default is .bitcoinNeutral4)
+///
+public struct BitcoinPlain: ButtonStyle {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.isEnabled) private var isEnabled
+    
+    let width: CGFloat
+    let height: CGFloat
+    let tintColor: Color
+    let disabledColor: Color
+    
+    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, tintColor: Color = defaultTintColor, disabledColor: Color = defaultDisabledTextColor) {
+        self.width = width
+        self.height = height
+        self.tintColor = tintColor
+        self.disabledColor = disabledColor
+    }
+
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(Font.body.bold())
+            .padding()
+            .frame(width: width, height: height)
+            .background(stateBackgroundColor().cornerRadius(cornerRadius))
+            .foregroundColor(stateTextColor())
             .scaleEffect(configuration.isPressed ? 0.95 : 1)
             .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
     }

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -24,9 +24,9 @@ public struct BitcoinFilled: ButtonStyle {
     let height: CGFloat
     let cornerRadius: CGFloat
     let tintColor: Color
-    let textColor = Color.bitcoinWhite
-    let disabledFillColor = Color.bitcoinNeutral2
-    let disabledTextColor = Color.bitcoinNeutral5
+    let textColor: Color
+    let disabledFillColor: Color
+    let disabledTextColor: Color
     
     public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, cornerRadius: CGFloat = defaultCornerRadius, tintColor: Color = defaultTintColor, textColor: Color = defaultTextColor, disabledFilleColor: Color = defaultDisabledFillColor, disabledTextColor: Color = defaultDisabledTextColor) {
         self.width = width

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -1,0 +1,84 @@
+//
+//  ButtonStyles.swift
+//  
+//
+//  Created by Daniel Nordh on 9/8/22.
+//
+
+import Foundation
+import SwiftUI
+
+/// A `ButtonStyle` according to the Filled type in the Bitcoin Wallet UI Kit
+///
+/// ```swift
+/// Button("Label") {
+///     print("Button pressed!")
+/// }
+///.buttonStyle(BitcoinFilled())
+/// ```
+/// - Parameter width: The width of the button (optional, default is 315.0)
+/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
+/// - Parameter tintColor: The background color of the button (optional, default is .bitcoinOrange)
+/// - Parameter textColor: The text color of the button (optional, default is .bitcoinWhite)
+/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
+struct BitcoinFilled: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled
+    var width = 315.0
+    var cornerRadius = 5.0
+    var tintColor = Color.bitcoinOrange
+    var textColor = Color.bitcoinWhite
+    var disabledColor = Color.bitcoinNeutral4
+    
+    func makeBody(configuration: Configuration) -> some View {
+        let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
+        configuration.label
+            .padding()
+            .frame(width: width, height: 46)
+            .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))
+            .foregroundColor(textColor)
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
+    }
+    func stateBackgroundColor(configuration: Configuration) -> Color {
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+    }
+}
+
+/// A `ButtonStyle` according to the Outline type in the Bitcoin Wallet UI Kit
+///
+/// ```swift
+/// Button("Label") {
+///     print("Button pressed!")
+/// }
+///.buttonStyle(BitcoinOutlined())
+/// ```
+/// - Parameter width: The width of the button (optional, default is 315.0)
+/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
+/// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
+/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
+struct BitcoinOutlined: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled
+    var width = 315.0
+    var cornerRadius = 5.0
+    var tintColor = Color.bitcoinOrange
+    var disabledColor = Color.bitcoinNeutral4
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .frame(width: width, height: 46)
+            .foregroundColor(stateForegroundColor())
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(stateBackgroundColor(configuration: configuration), lineWidth: 1.5)
+                )
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
+    }
+    func stateBackgroundColor(configuration: Configuration) -> Color {
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+    }
+    func stateForegroundColor() -> Color {
+        return isEnabled ? tintColor : disabledColor
+    }
+}

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -129,34 +129,34 @@ public struct BitcoinOutlined: ButtonStyle {
 /// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
 /// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
 /// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
-public struct BitcoinOutlined: ButtonStyle {
-    @Environment(\.isEnabled) var isEnabled
-    @Environment(\.colorScheme) var colorScheme
-    var width = 315.0
-    var cornerRadius = 5.0
-    var tintColor = Color.bitcoinOrange
-    var disabledColor = Color.bitcoinNeutral4
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding()
-            .frame(width: width, height: 46)
-            .background(stateBackgroundColor().cornerRadius(cornerRadius))
-            .foregroundColor(stateTextColor())
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
-                )
-            .scaleEffect(configuration.isPressed ? 0.95 : 1)
-            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
-    }
-    func stateBackgroundColor() -> Color {
-        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
-    }
-    func stateBorderColor(configuration: Configuration) -> Color {
-        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
-    }
-    func stateTextColor() -> Color {
-        return isEnabled ? tintColor : disabledColor
-    }
-}
+//public struct BitcoinOutlined: ButtonStyle {
+//    @Environment(\.isEnabled) var isEnabled
+//    @Environment(\.colorScheme) var colorScheme
+//    var width = 315.0
+//    var cornerRadius = 5.0
+//    var tintColor = Color.bitcoinOrange
+//    var disabledColor = Color.bitcoinNeutral4
+//
+//    func makeBody(configuration: Configuration) -> some View {
+//        configuration.label
+//            .padding()
+//            .frame(width: width, height: 46)
+//            .background(stateBackgroundColor().cornerRadius(cornerRadius))
+//            .foregroundColor(stateTextColor())
+//            .overlay(
+//                RoundedRectangle(cornerRadius: cornerRadius)
+//                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
+//                )
+//            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+//            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+//    }
+//    func stateBackgroundColor() -> Color {
+//        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
+//    }
+//    func stateBorderColor(configuration: Configuration) -> Color {
+//        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+//    }
+//    func stateTextColor() -> Color {
+//        return isEnabled ? tintColor : disabledColor
+//    }
+//}

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -42,7 +42,7 @@ public struct BitcoinFilled: ButtonStyle {
         let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
         configuration.label
             .padding()
-            .frame(width: width, height: 46)
+            .frame(width: width, height: height)
             .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))
             .foregroundColor(stateTextColor())
             .scaleEffect(configuration.isPressed ? 0.95 : 1)

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -27,7 +27,8 @@ struct BitcoinFilled: ButtonStyle {
     var cornerRadius = 5.0
     var tintColor = Color.bitcoinOrange
     var textColor = Color.bitcoinWhite
-    var disabledColor = Color.bitcoinNeutral4
+    var disabledColor = Color.bitcoinNeutral2
+    var disabledTextColor = Color.bitcoinNeutral5
     
     func makeBody(configuration: Configuration) -> some View {
         let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
@@ -35,12 +36,15 @@ struct BitcoinFilled: ButtonStyle {
             .padding()
             .frame(width: width, height: 46)
             .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))
-            .foregroundColor(textColor)
+            .foregroundColor(stateTextColor())
             .scaleEffect(configuration.isPressed ? 0.95 : 1)
-            .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
     }
     func stateBackgroundColor(configuration: Configuration) -> Color {
         return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+    }
+    func stateTextColor() -> Color {
+        return isEnabled ? textColor : disabledTextColor
     }
 }
 
@@ -58,6 +62,7 @@ struct BitcoinFilled: ButtonStyle {
 /// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
 struct BitcoinOutlined: ButtonStyle {
     @Environment(\.isEnabled) var isEnabled
+    @Environment(\.colorScheme) var colorScheme
     var width = 315.0
     var cornerRadius = 5.0
     var tintColor = Color.bitcoinOrange
@@ -67,18 +72,22 @@ struct BitcoinOutlined: ButtonStyle {
         configuration.label
             .padding()
             .frame(width: width, height: 46)
-            .foregroundColor(stateForegroundColor())
+            .background(stateBackgroundColor().cornerRadius(cornerRadius))
+            .foregroundColor(stateTextColor())
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius)
-                    .stroke(stateBackgroundColor(configuration: configuration), lineWidth: 1.5)
+                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
                 )
             .scaleEffect(configuration.isPressed ? 0.95 : 1)
-            .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
     }
-    func stateBackgroundColor(configuration: Configuration) -> Color {
+    func stateBackgroundColor() -> Color {
+        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
+    }
+    func stateBorderColor(configuration: Configuration) -> Color {
         return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
     }
-    func stateForegroundColor() -> Color {
+    func stateTextColor() -> Color {
         return isEnabled ? tintColor : disabledColor
     }
 }

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -58,7 +58,7 @@ public struct BitcoinFilled: ButtonStyle {
     public func makeBody(configuration: Configuration) -> some View {
         let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
         configuration.label
-            .font(.system.bold())
+            .fontWeight(.bold)
             .padding()
             .frame(width: width, height: height)
             .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -58,6 +58,7 @@ public struct BitcoinFilled: ButtonStyle {
     public func makeBody(configuration: Configuration) -> some View {
         let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
         configuration.label
+            .font(.system.bold())
             .padding()
             .frame(width: width, height: height)
             .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -12,7 +12,7 @@ public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
     
-    var width = 315.0
+    let width: CGFloat?
     let cornerRadius = 5.0
     let tintColor = Color.bitcoinOrange
     let textColor = Color.bitcoinWhite
@@ -20,7 +20,7 @@ public struct BitcoinFilled: ButtonStyle {
     let disabledTextColor = Color.bitcoinNeutral5
     
     public init(width: CGFloat?) {
-        self.width = width ?? self.width
+        self.width = width ?? 315.0
     }
 
     public func makeBody(configuration: Configuration) -> some View {

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 
 public struct NeumorphicButtonStyle: ButtonStyle {
+    @Environment(\.colorScheme) private var colorScheme
 
     public struct Appearance {
         public var cornerRadius: CGFloat = 12
@@ -19,8 +20,6 @@ public struct NeumorphicButtonStyle: ButtonStyle {
     }
 
     public let appearance: Appearance
-
-    public let colorScheme: ColorScheme
 
     private var buttonColor: Color {
         switch colorScheme {
@@ -129,8 +128,7 @@ public struct NeumorphicButtonStyle: ButtonStyle {
         )
     }
 
-    public init(colorScheme: ColorScheme, appearance: Appearance = Appearance()) {
-        self.colorScheme = colorScheme
+    public init(appearance: Appearance = Appearance()) {
         self.appearance = appearance
     }
 

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -12,7 +12,7 @@ public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
     
-    let width: CGFloat
+    var width = 315.0
     let cornerRadius = 5.0
     let tintColor = Color.bitcoinOrange
     let textColor = Color.bitcoinWhite
@@ -20,7 +20,7 @@ public struct BitcoinFilled: ButtonStyle {
     let disabledTextColor = Color.bitcoinNeutral5
     
     public init(width: CGFloat?) {
-        self.width = width ?? 315.0
+        self.width = width ?? self.width
     }
 
     public func makeBody(configuration: Configuration) -> some View {

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -8,155 +8,42 @@
 import Foundation
 import SwiftUI
 
-public struct NeumorphicButtonStyle: ButtonStyle {
+public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
-
-    public struct Appearance {
-        public var cornerRadius: CGFloat = 12
-        public var lightColor: Color = .hex("E8EEF6")
-        public var darkColor: Color = .hex("1E212B")
-
-        public init() { }
+    @Environment(\.isEnabled) private var isEnabled
+    
+    let width = 315.0
+    let cornerRadius = 5.0
+    let tintColor = Color.bitcoinOrange
+    let textColor = Color.bitcoinWhite
+    let disabledColor = Color.bitcoinNeutral2
+    let disabledTextColor = Color.bitcoinNeutral5
+    
+    public init(width: CGFloat?) {
+        self.width = width ?? 315.0
     }
 
-    public let appearance: Appearance
-
-    private var buttonColor: Color {
-        switch colorScheme {
-        case .light: return appearance.lightColor
-        case .dark: return appearance.darkColor
-        @unknown default: return appearance.lightColor
-        }
-    }
-
-    private var topShadowColor: Color {
-        switch colorScheme {
-        case .light: return .white
-        case .dark: return Color.white.opacity(0.52)
-        @unknown default: return .white
-        }
-    }
-
-    private var bottomShadowColor: Color {
-        switch colorScheme {
-        case .light: return Color.black.opacity(0.8)
-        case .dark: return Color.black.opacity(0.48)
-        @unknown default: return Color.black.opacity(0.8)
-        }
-    }
-
-    private func borderColor(_ configuration: Self.Configuration) -> Color {
-        switch colorScheme {
-        case .light: return Color.white.opacity(configuration.isPressed ? 0.24 : 0.1)
-        case .dark: return Color.white.opacity(configuration.isPressed ? 0.07 : 0.05)
-        @unknown default: return Color.white.opacity(configuration.isPressed ? 0.24 : 0.1)
-        }
-    }
-
-    private func overlayColor(_ configuration: Self.Configuration) -> Color {
-        switch colorScheme {
-        case .light:
-            return configuration.isPressed ? Color.white.opacity(0.001) : Color.white.opacity(0.14)
-        case .dark:
-            return configuration.isPressed ? Color.white.opacity(0.001) : Color.white.opacity(0.01)
-        @unknown default:
-            return configuration.isPressed ? Color.white.opacity(0.001) : Color.white.opacity(0.14)
-        }
-    }
-
-    private func radius(_ configuration: Self.Configuration) -> CGFloat {
-        configuration.isPressed ? 6 : 13
-    }
-
-    private func shadowView(_ configuration: Self.Configuration) -> some View {
-        let shadows = RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
-            .foregroundColor(.white)
-            .shadow(
-                color: topShadowColor,
-                radius: radius(configuration),
-                x: configuration.isPressed ? -2 : -6,
-                y: configuration.isPressed ? -4 : -8
-        )
-            .shadow(
-                color: bottomShadowColor,
-                radius: radius(configuration),
-                x: configuration.isPressed ? 2 : 6,
-                y: configuration.isPressed ? 4 : 8
-        )
-            .blendMode(.overlay)
-            .padding(6)
-
-        switch colorScheme {
-        case .light: return AnyView(ZStack(content: {
-            shadows
-            shadows
-        }))
-        default: return AnyView(shadows)
-        }
-    }
-
-    public func makeBody(configuration: Self.Configuration) -> some View {
+    public func makeBody(configuration: Configuration) -> some View {
+        let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
         configuration.label
             .padding()
-            .background(
-                ZStack {
-                    shadowView(configuration)
-
-                    RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
-                        .foregroundColor(buttonColor)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
-                                .foregroundColor(overlayColor(configuration))
-                                .blendMode(.overlay)
-                    )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
-                                .stroke(borderColor(configuration))
-                                .blendMode(.overlay)
-                    )
-                }
-
-        )
-            .scaleEffect(configuration.isPressed ? 0.99 : 1)
-            .animation(
-                .interactiveSpring(
-                    response: configuration.isPressed ? 0.24 : 0.3,
-                    dampingFraction: 0.4,
-                    blendDuration: 0.6
-                ),
-                value: configuration.isPressed
-        )
+            .frame(width: width, height: 46)
+            .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))
+            .foregroundColor(stateTextColor())
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
     }
 
-    public init(appearance: Appearance = Appearance()) {
-        self.appearance = appearance
+    private func stateBackgroundColor(configuration: Configuration) -> Color {
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
     }
-
+    
+    private func stateTextColor() -> Color {
+        return isEnabled ? textColor : disabledTextColor
+    }
 }
 
-public extension Color {
 
-    static func hex(_ hex: String) -> Self {
-        let scanner = Scanner(string: hex)
-        scanner.currentIndex = .init(utf16Offset: 0, in: hex)
-        var rgbValue: UInt64 = 0
-        scanner.scanHexInt64(&rgbValue)
-
-        let r = (rgbValue & 0xff0000) >> 16
-        let g = (rgbValue & 0xff00) >> 8
-        let b = rgbValue & 0xff
-
-        return Self.init(
-            red: Double(r) / 0xff,
-            green: Double(g) / 0xff,
-            blue: Double(b) / 0xff,
-            opacity: 1
-        )
-    }
-
-}
-
-//
 ///// A `ButtonStyle` according to the Filled type in the Bitcoin Wallet UI Kit
 /////
 ///// ```swift

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -34,7 +34,7 @@ public struct BitcoinFilled: ButtonStyle {
         self.cornerRadius = cornerRadius
         self.tintColor = tintColor
         self.textColor = textColor
-        self.disabledColor = disabledFilleColor
+        self.disabledFillColor = disabledFilleColor
         self.disabledTextColor = disabledTextColor
     }
 

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -8,19 +8,24 @@
 import Foundation
 import SwiftUI
 
+private let defaultButtonWidth = 315.0
+private let defaultButtonHeight = 48.0
+
 public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
     
     let width: CGFloat
+    let height: CGFloat
     let cornerRadius = 5.0
     let tintColor = Color.bitcoinOrange
     let textColor = Color.bitcoinWhite
     let disabledColor = Color.bitcoinNeutral2
     let disabledTextColor = Color.bitcoinNeutral5
     
-    public init(width: CGFloat = 315.0) {
+    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight) {
         self.width = width
+        self.height = height
     }
 
     public func makeBody(configuration: Configuration) -> some View {

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -129,7 +129,7 @@ public struct BitcoinOutlined: ButtonStyle {
         return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
     }
     private func stateTextColor() -> Color {
-        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+        return isEnabled ? tintColor : disabledColor
     }
 }
 

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -23,12 +23,21 @@ import SwiftUI
 /// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
 struct BitcoinFilled: ButtonStyle {
     @Environment(\.isEnabled) var isEnabled
-    var width = 315.0
-    var cornerRadius = 5.0
-    var tintColor = Color.bitcoinOrange
-    var textColor = Color.bitcoinWhite
-    var disabledColor = Color.bitcoinNeutral2
-    var disabledTextColor = Color.bitcoinNeutral5
+    let width = 315.0
+    let cornerRadius = 5.0
+    let tintColor = Color.bitcoinOrange
+    let textColor = Color.bitcoinWhite
+    let disabledColor = Color.bitcoinNeutral2
+    let disabledTextColor = Color.bitcoinNeutral5
+    
+    public init(width: CGFloat?) {
+        self.width = width ?? 315.0
+        self.cornerRadius = 5.0
+        self.tintColor = Color.bitcoinOrange
+        self.textColor = Color.bitcoinWhite
+        self.disabledColor = Color.bitcoinNeutral2
+        self.disabledTextColor = Color.bitcoinNeutral5
+    }
     
     func makeBody(configuration: Configuration) -> some View {
         let stateBackgroundColor = stateBackgroundColor(configuration: configuration)

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -15,6 +15,7 @@ public let defaultTintColor = Color.bitcoinOrange
 public let defaultTextColor = Color.bitcoinWhite
 public let defaultDisabledFillColor = Color.bitcoinNeutral2
 public let defaultDisabledTextColor = Color.bitcoinNeutral5
+public let defaultDisabledOutlineColor = Color.bitcoinNeutral4
 
 /// A `ButtonStyle` corresponding to the Filled type in the Bitcoin Wallet UI Kit
 ///
@@ -74,6 +75,20 @@ public struct BitcoinFilled: ButtonStyle {
     }
 }
 
+/// A `ButtonStyle` corresponding to the Outline type in the Bitcoin Wallet UI Kit
+///
+/// ```swift
+/// Button("Label") {
+///     print("Button pressed!")
+/// }
+///.buttonStyle(BitcoinOutlined())
+/// ```
+/// - Parameter width: The width of the button (optional, default is 315.0)
+/// - Parameter height: The width of the button (optional, default is 48.0)
+/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
+/// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
+/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
+///
 public struct BitcoinOutlined: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
@@ -84,7 +99,7 @@ public struct BitcoinOutlined: ButtonStyle {
     let tintColor: Color
     let disabledColor: Color
     
-    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, cornerRadius: CGFloat = defaultCornerRadius, tintColor: Color = defaultTintColor, disabledColor: Color = defaultDisabledTextColor) {
+    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, cornerRadius: CGFloat = defaultCornerRadius, tintColor: Color = defaultTintColor, disabledColor: Color = defaultDisabledOutlineColor) {
         self.width = width
         self.height = height
         self.cornerRadius = cornerRadius
@@ -115,48 +130,3 @@ public struct BitcoinOutlined: ButtonStyle {
         return isEnabled ? tintColor : disabledColor
     }
 }
-
-
-/// A `ButtonStyle` according to the Outline type in the Bitcoin Wallet UI Kit
-///
-/// ```swift
-/// Button("Label") {
-///     print("Button pressed!")
-/// }
-///.buttonStyle(BitcoinOutlined())
-/// ```
-/// - Parameter width: The width of the button (optional, default is 315.0)
-/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
-/// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
-/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
-//public struct BitcoinOutlined: ButtonStyle {
-//    @Environment(\.isEnabled) var isEnabled
-//    @Environment(\.colorScheme) var colorScheme
-//    var width = 315.0
-//    var cornerRadius = 5.0
-//    var tintColor = Color.bitcoinOrange
-//    var disabledColor = Color.bitcoinNeutral4
-//
-//    func makeBody(configuration: Configuration) -> some View {
-//        configuration.label
-//            .padding()
-//            .frame(width: width, height: 46)
-//            .background(stateBackgroundColor().cornerRadius(cornerRadius))
-//            .foregroundColor(stateTextColor())
-//            .overlay(
-//                RoundedRectangle(cornerRadius: cornerRadius)
-//                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
-//                )
-//            .scaleEffect(configuration.isPressed ? 0.95 : 1)
-//            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
-//    }
-//    func stateBackgroundColor() -> Color {
-//        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
-//    }
-//    func stateBorderColor(configuration: Configuration) -> Color {
-//        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
-//    }
-//    func stateTextColor() -> Color {
-//        return isEnabled ? tintColor : disabledColor
-//    }
-//}

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -110,8 +110,9 @@ public struct BitcoinOutlined: ButtonStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         configuration.label
+            .font(Font.body.bold())
             .padding()
-            .frame(width: width, height: 46)
+            .frame(width: width, height: height)
             .background(stateBackgroundColor().cornerRadius(cornerRadius))
             .foregroundColor(stateTextColor())
             .overlay(

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -58,7 +58,7 @@ public struct BitcoinFilled: ButtonStyle {
     public func makeBody(configuration: Configuration) -> some View {
         let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
         configuration.label
-            .fontWeight(.bold)
+            .font(Font.body.bold())
             .padding()
             .frame(width: width, height: height)
             .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -92,7 +92,7 @@ public struct BitcoinOutlined: ButtonStyle {
         self.disabledColor = disabledColor
     }
 
-    func makeBody(configuration: Configuration) -> some View {
+    public func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .padding()
             .frame(width: width, height: 46)
@@ -105,13 +105,13 @@ public struct BitcoinOutlined: ButtonStyle {
             .scaleEffect(configuration.isPressed ? 0.95 : 1)
             .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
     }
-    func stateBackgroundColor() -> Color {
+    private func stateBackgroundColor() -> Color {
         return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
     }
-    func stateBorderColor(configuration: Configuration) -> Color {
+    private func stateBorderColor(configuration: Configuration) -> Color {
         return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
     }
-    func stateTextColor() -> Color {
+    private func stateTextColor() -> Color {
         return isEnabled ? tintColor : disabledColor
     }
 }

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -129,7 +129,7 @@ public struct BitcoinOutlined: ButtonStyle {
         return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
     }
     private func stateTextColor() -> Color {
-        return isEnabled ? tintColor : disabledColor
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
     }
 }
 

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -39,7 +39,7 @@ public struct BitcoinFilled: ButtonStyle {
         self.disabledTextColor = Color.bitcoinNeutral5
     }
     
-    func makeBody(configuration: Configuration) -> some View {
+    public func makeBody(configuration: Configuration) -> some View {
         let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
         configuration.label
             .padding()

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -12,15 +12,15 @@ public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
     
-    let width: CGFloat?
+    let width: CGFloat
     let cornerRadius = 5.0
     let tintColor = Color.bitcoinOrange
     let textColor = Color.bitcoinWhite
     let disabledColor = Color.bitcoinNeutral2
     let disabledTextColor = Color.bitcoinNeutral5
     
-    public init(width: CGFloat?) {
-        self.width = width ?? 315.0
+    public init(width: CGFloat = 315.0) {
+        self.width
     }
 
     public func makeBody(configuration: Configuration) -> some View {

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -12,7 +12,7 @@ public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
     
-    let width = 315.0
+    let width: CGFloat
     let cornerRadius = 5.0
     let tintColor = Color.bitcoinOrange
     let textColor = Color.bitcoinWhite

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -16,6 +16,22 @@ public let defaultTextColor = Color.bitcoinWhite
 public let defaultDisabledFillColor = Color.bitcoinNeutral2
 public let defaultDisabledTextColor = Color.bitcoinNeutral5
 
+/// A `ButtonStyle` corresponding to the Filled type in the Bitcoin Wallet UI Kit
+///
+/// ```swift
+/// Button("Label") {
+///     print("Button pressed!")
+/// }
+///.buttonStyle(BitcoinFilled())
+/// ```
+/// - Parameter width: The width of the button (optional, default is 315.0)
+/// - Parameter height: The width of the button (optional, default is 48.0)
+/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
+/// - Parameter tintColor: The background color of the button (optional, default is .bitcoinOrange)
+/// - Parameter textColor: The text color of the button (optional, default is .bitcoinWhite)
+/// - Parameter disabledFillColor: The disabled background color of the button (optional, default is .bitcoinNeutral2)
+/// - Parameter disabledTextColor: The disabled text color of the button (optional, default is .bitcoinNeutral5)
+///
 public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
@@ -28,13 +44,13 @@ public struct BitcoinFilled: ButtonStyle {
     let disabledFillColor: Color
     let disabledTextColor: Color
     
-    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, cornerRadius: CGFloat = defaultCornerRadius, tintColor: Color = defaultTintColor, textColor: Color = defaultTextColor, disabledFilleColor: Color = defaultDisabledFillColor, disabledTextColor: Color = defaultDisabledTextColor) {
+    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, cornerRadius: CGFloat = defaultCornerRadius, tintColor: Color = defaultTintColor, textColor: Color = defaultTextColor, disabledFillColor: Color = defaultDisabledFillColor, disabledTextColor: Color = defaultDisabledTextColor) {
         self.width = width
         self.height = height
         self.cornerRadius = cornerRadius
         self.tintColor = tintColor
         self.textColor = textColor
-        self.disabledFillColor = disabledFilleColor
+        self.disabledFillColor = disabledFillColor
         self.disabledTextColor = disabledTextColor
     }
 
@@ -58,96 +74,89 @@ public struct BitcoinFilled: ButtonStyle {
     }
 }
 
+public struct BitcoinOutlined: ButtonStyle {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.isEnabled) private var isEnabled
+    
+    let width: CGFloat
+    let height: CGFloat
+    let cornerRadius: CGFloat
+    let tintColor: Color
+    let disabledColor: Color
+    
+    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, cornerRadius: CGFloat = defaultCornerRadius, tintColor: Color = defaultTintColor, disabledColor: Color = defaultDisabledTextColor) {
+        self.width = width
+        self.height = height
+        self.cornerRadius = cornerRadius
+        self.tintColor = tintColor
+        self.disabledColor = disabledColor
+    }
 
-///// A `ButtonStyle` according to the Filled type in the Bitcoin Wallet UI Kit
-/////
-///// ```swift
-///// Button("Label") {
-/////     print("Button pressed!")
-///// }
-/////.buttonStyle(BitcoinFilled())
-///// ```
-///// - Parameter width: The width of the button (optional, default is 315.0)
-///// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
-///// - Parameter tintColor: The background color of the button (optional, default is .bitcoinOrange)
-///// - Parameter textColor: The text color of the button (optional, default is .bitcoinWhite)
-///// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
-//public struct BitcoinFilled: ButtonStyle {
-//    @Environment(\.isEnabled) var isEnabled
-//    let width = 315.0
-//    let cornerRadius = 5.0
-//    let tintColor = Color.bitcoinOrange
-//    let textColor = Color.bitcoinWhite
-//    let disabledColor = Color.bitcoinNeutral2
-//    let disabledTextColor = Color.bitcoinNeutral5
-//
-//    public init(width: CGFloat?) {
-//        self.width = width ?? 315.0
-//        self.cornerRadius = 5.0
-//        self.tintColor = Color.bitcoinOrange
-//        self.textColor = Color.bitcoinWhite
-//        self.disabledColor = Color.bitcoinNeutral2
-//        self.disabledTextColor = Color.bitcoinNeutral5
-//    }
-//
-//    public func makeBody(configuration: Configuration) -> some View {
-//        let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
-//        configuration.label
-//            .padding()
-//            .frame(width: width, height: 46)
-//            .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))
-//            .foregroundColor(stateTextColor())
-//            .scaleEffect(configuration.isPressed ? 0.95 : 1)
-//            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
-//    }
-//    func stateBackgroundColor(configuration: Configuration) -> Color {
-//        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
-//    }
-//    func stateTextColor() -> Color {
-//        return isEnabled ? textColor : disabledTextColor
-//    }
-//}
-//
-///// A `ButtonStyle` according to the Outline type in the Bitcoin Wallet UI Kit
-/////
-///// ```swift
-///// Button("Label") {
-/////     print("Button pressed!")
-///// }
-/////.buttonStyle(BitcoinOutlined())
-///// ```
-///// - Parameter width: The width of the button (optional, default is 315.0)
-///// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
-///// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
-///// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
-//public struct BitcoinOutlined: ButtonStyle {
-//    @Environment(\.isEnabled) var isEnabled
-//    @Environment(\.colorScheme) var colorScheme
-//    var width = 315.0
-//    var cornerRadius = 5.0
-//    var tintColor = Color.bitcoinOrange
-//    var disabledColor = Color.bitcoinNeutral4
-//
-//    func makeBody(configuration: Configuration) -> some View {
-//        configuration.label
-//            .padding()
-//            .frame(width: width, height: 46)
-//            .background(stateBackgroundColor().cornerRadius(cornerRadius))
-//            .foregroundColor(stateTextColor())
-//            .overlay(
-//                RoundedRectangle(cornerRadius: cornerRadius)
-//                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
-//                )
-//            .scaleEffect(configuration.isPressed ? 0.95 : 1)
-//            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
-//    }
-//    func stateBackgroundColor() -> Color {
-//        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
-//    }
-//    func stateBorderColor(configuration: Configuration) -> Color {
-//        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
-//    }
-//    func stateTextColor() -> Color {
-//        return isEnabled ? tintColor : disabledColor
-//    }
-//}
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .frame(width: width, height: 46)
+            .background(stateBackgroundColor().cornerRadius(cornerRadius))
+            .foregroundColor(stateTextColor())
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
+                )
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+    func stateBackgroundColor() -> Color {
+        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
+    }
+    func stateBorderColor(configuration: Configuration) -> Color {
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+    }
+    func stateTextColor() -> Color {
+        return isEnabled ? tintColor : disabledColor
+    }
+}
+
+
+/// A `ButtonStyle` according to the Outline type in the Bitcoin Wallet UI Kit
+///
+/// ```swift
+/// Button("Label") {
+///     print("Button pressed!")
+/// }
+///.buttonStyle(BitcoinOutlined())
+/// ```
+/// - Parameter width: The width of the button (optional, default is 315.0)
+/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
+/// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
+/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
+public struct BitcoinOutlined: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled
+    @Environment(\.colorScheme) var colorScheme
+    var width = 315.0
+    var cornerRadius = 5.0
+    var tintColor = Color.bitcoinOrange
+    var disabledColor = Color.bitcoinNeutral4
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .frame(width: width, height: 46)
+            .background(stateBackgroundColor().cornerRadius(cornerRadius))
+            .foregroundColor(stateTextColor())
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
+                )
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+    func stateBackgroundColor() -> Color {
+        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
+    }
+    func stateBorderColor(configuration: Configuration) -> Color {
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+    }
+    func stateTextColor() -> Color {
+        return isEnabled ? tintColor : disabledColor
+    }
+}

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -167,7 +167,7 @@ public struct BitcoinPlain: ButtonStyle {
             .font(Font.body.bold())
             .padding()
             .frame(width: width, height: height)
-            .background(stateBackgroundColor().cornerRadius(cornerRadius))
+            .background(stateBackgroundColor())
             .foregroundColor(stateTextColor())
             .scaleEffect(configuration.isPressed ? 0.95 : 1)
             .animation(.easeOut(duration: 0.1), value: configuration.isPressed)

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -8,95 +8,246 @@
 import Foundation
 import SwiftUI
 
-/// A `ButtonStyle` according to the Filled type in the Bitcoin Wallet UI Kit
-///
-/// ```swift
-/// Button("Label") {
-///     print("Button pressed!")
-/// }
-///.buttonStyle(BitcoinFilled())
-/// ```
-/// - Parameter width: The width of the button (optional, default is 315.0)
-/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
-/// - Parameter tintColor: The background color of the button (optional, default is .bitcoinOrange)
-/// - Parameter textColor: The text color of the button (optional, default is .bitcoinWhite)
-/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
-public struct BitcoinFilled: ButtonStyle {
-    @Environment(\.isEnabled) var isEnabled
-    let width = 315.0
-    let cornerRadius = 5.0
-    let tintColor = Color.bitcoinOrange
-    let textColor = Color.bitcoinWhite
-    let disabledColor = Color.bitcoinNeutral2
-    let disabledTextColor = Color.bitcoinNeutral5
-    
-    public init(width: CGFloat?) {
-        self.width = width ?? 315.0
-        self.cornerRadius = 5.0
-        self.tintColor = Color.bitcoinOrange
-        self.textColor = Color.bitcoinWhite
-        self.disabledColor = Color.bitcoinNeutral2
-        self.disabledTextColor = Color.bitcoinNeutral5
+public struct NeumorphicButtonStyle: ButtonStyle {
+
+    public struct Appearance {
+        public var cornerRadius: CGFloat = 12
+        public var lightColor: Color = .hex("E8EEF6")
+        public var darkColor: Color = .hex("1E212B")
+
+        public init() { }
     }
-    
-    public func makeBody(configuration: Configuration) -> some View {
-        let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
+
+    public let appearance: Appearance
+
+    public let colorScheme: ColorScheme
+
+    private var buttonColor: Color {
+        switch colorScheme {
+        case .light: return appearance.lightColor
+        case .dark: return appearance.darkColor
+        @unknown default: return appearance.lightColor
+        }
+    }
+
+    private var topShadowColor: Color {
+        switch colorScheme {
+        case .light: return .white
+        case .dark: return Color.white.opacity(0.52)
+        @unknown default: return .white
+        }
+    }
+
+    private var bottomShadowColor: Color {
+        switch colorScheme {
+        case .light: return Color.black.opacity(0.8)
+        case .dark: return Color.black.opacity(0.48)
+        @unknown default: return Color.black.opacity(0.8)
+        }
+    }
+
+    private func borderColor(_ configuration: Self.Configuration) -> Color {
+        switch colorScheme {
+        case .light: return Color.white.opacity(configuration.isPressed ? 0.24 : 0.1)
+        case .dark: return Color.white.opacity(configuration.isPressed ? 0.07 : 0.05)
+        @unknown default: return Color.white.opacity(configuration.isPressed ? 0.24 : 0.1)
+        }
+    }
+
+    private func overlayColor(_ configuration: Self.Configuration) -> Color {
+        switch colorScheme {
+        case .light:
+            return configuration.isPressed ? Color.white.opacity(0.001) : Color.white.opacity(0.14)
+        case .dark:
+            return configuration.isPressed ? Color.white.opacity(0.001) : Color.white.opacity(0.01)
+        @unknown default:
+            return configuration.isPressed ? Color.white.opacity(0.001) : Color.white.opacity(0.14)
+        }
+    }
+
+    private func radius(_ configuration: Self.Configuration) -> CGFloat {
+        configuration.isPressed ? 6 : 13
+    }
+
+    private func shadowView(_ configuration: Self.Configuration) -> some View {
+        let shadows = RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
+            .foregroundColor(.white)
+            .shadow(
+                color: topShadowColor,
+                radius: radius(configuration),
+                x: configuration.isPressed ? -2 : -6,
+                y: configuration.isPressed ? -4 : -8
+        )
+            .shadow(
+                color: bottomShadowColor,
+                radius: radius(configuration),
+                x: configuration.isPressed ? 2 : 6,
+                y: configuration.isPressed ? 4 : 8
+        )
+            .blendMode(.overlay)
+            .padding(6)
+
+        switch colorScheme {
+        case .light: return AnyView(ZStack(content: {
+            shadows
+            shadows
+        }))
+        default: return AnyView(shadows)
+        }
+    }
+
+    public func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
             .padding()
-            .frame(width: width, height: 46)
-            .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))
-            .foregroundColor(stateTextColor())
-            .scaleEffect(configuration.isPressed ? 0.95 : 1)
-            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+            .background(
+                ZStack {
+                    shadowView(configuration)
+
+                    RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
+                        .foregroundColor(buttonColor)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
+                                .foregroundColor(overlayColor(configuration))
+                                .blendMode(.overlay)
+                    )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: appearance.cornerRadius, style: .continuous)
+                                .stroke(borderColor(configuration))
+                                .blendMode(.overlay)
+                    )
+                }
+
+        )
+            .scaleEffect(configuration.isPressed ? 0.99 : 1)
+            .animation(
+                .interactiveSpring(
+                    response: configuration.isPressed ? 0.24 : 0.3,
+                    dampingFraction: 0.4,
+                    blendDuration: 0.6
+                ),
+                value: configuration.isPressed
+        )
     }
-    func stateBackgroundColor(configuration: Configuration) -> Color {
-        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+
+    public init(colorScheme: ColorScheme, appearance: Appearance = Appearance()) {
+        self.colorScheme = colorScheme
+        self.appearance = appearance
     }
-    func stateTextColor() -> Color {
-        return isEnabled ? textColor : disabledTextColor
-    }
+
 }
 
-/// A `ButtonStyle` according to the Outline type in the Bitcoin Wallet UI Kit
-///
-/// ```swift
-/// Button("Label") {
-///     print("Button pressed!")
-/// }
-///.buttonStyle(BitcoinOutlined())
-/// ```
-/// - Parameter width: The width of the button (optional, default is 315.0)
-/// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
-/// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
-/// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
-public struct BitcoinOutlined: ButtonStyle {
-    @Environment(\.isEnabled) var isEnabled
-    @Environment(\.colorScheme) var colorScheme
-    var width = 315.0
-    var cornerRadius = 5.0
-    var tintColor = Color.bitcoinOrange
-    var disabledColor = Color.bitcoinNeutral4
-    
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding()
-            .frame(width: width, height: 46)
-            .background(stateBackgroundColor().cornerRadius(cornerRadius))
-            .foregroundColor(stateTextColor())
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
-                )
-            .scaleEffect(configuration.isPressed ? 0.95 : 1)
-            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+public extension Color {
+
+    static func hex(_ hex: String) -> Self {
+        let scanner = Scanner(string: hex)
+        scanner.currentIndex = .init(utf16Offset: 0, in: hex)
+        var rgbValue: UInt64 = 0
+        scanner.scanHexInt64(&rgbValue)
+
+        let r = (rgbValue & 0xff0000) >> 16
+        let g = (rgbValue & 0xff00) >> 8
+        let b = rgbValue & 0xff
+
+        return Self.init(
+            red: Double(r) / 0xff,
+            green: Double(g) / 0xff,
+            blue: Double(b) / 0xff,
+            opacity: 1
+        )
     }
-    func stateBackgroundColor() -> Color {
-        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
-    }
-    func stateBorderColor(configuration: Configuration) -> Color {
-        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
-    }
-    func stateTextColor() -> Color {
-        return isEnabled ? tintColor : disabledColor
-    }
+
 }
+
+//
+///// A `ButtonStyle` according to the Filled type in the Bitcoin Wallet UI Kit
+/////
+///// ```swift
+///// Button("Label") {
+/////     print("Button pressed!")
+///// }
+/////.buttonStyle(BitcoinFilled())
+///// ```
+///// - Parameter width: The width of the button (optional, default is 315.0)
+///// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
+///// - Parameter tintColor: The background color of the button (optional, default is .bitcoinOrange)
+///// - Parameter textColor: The text color of the button (optional, default is .bitcoinWhite)
+///// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
+//public struct BitcoinFilled: ButtonStyle {
+//    @Environment(\.isEnabled) var isEnabled
+//    let width = 315.0
+//    let cornerRadius = 5.0
+//    let tintColor = Color.bitcoinOrange
+//    let textColor = Color.bitcoinWhite
+//    let disabledColor = Color.bitcoinNeutral2
+//    let disabledTextColor = Color.bitcoinNeutral5
+//
+//    public init(width: CGFloat?) {
+//        self.width = width ?? 315.0
+//        self.cornerRadius = 5.0
+//        self.tintColor = Color.bitcoinOrange
+//        self.textColor = Color.bitcoinWhite
+//        self.disabledColor = Color.bitcoinNeutral2
+//        self.disabledTextColor = Color.bitcoinNeutral5
+//    }
+//
+//    public func makeBody(configuration: Configuration) -> some View {
+//        let stateBackgroundColor = stateBackgroundColor(configuration: configuration)
+//        configuration.label
+//            .padding()
+//            .frame(width: width, height: 46)
+//            .background(stateBackgroundColor.opacity(0.8).cornerRadius(cornerRadius))
+//            .foregroundColor(stateTextColor())
+//            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+//            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+//    }
+//    func stateBackgroundColor(configuration: Configuration) -> Color {
+//        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+//    }
+//    func stateTextColor() -> Color {
+//        return isEnabled ? textColor : disabledTextColor
+//    }
+//}
+//
+///// A `ButtonStyle` according to the Outline type in the Bitcoin Wallet UI Kit
+/////
+///// ```swift
+///// Button("Label") {
+/////     print("Button pressed!")
+///// }
+/////.buttonStyle(BitcoinOutlined())
+///// ```
+///// - Parameter width: The width of the button (optional, default is 315.0)
+///// - Parameter cornerRadius: The corner radius of the button (optional, default is 5.0)
+///// - Parameter tintColor: The border color of the button (optional, default is .bitcoinOrange)
+///// - Parameter disabledColor: The disabled background color of the button (optional, default is .bitcoinNeutral4)
+//public struct BitcoinOutlined: ButtonStyle {
+//    @Environment(\.isEnabled) var isEnabled
+//    @Environment(\.colorScheme) var colorScheme
+//    var width = 315.0
+//    var cornerRadius = 5.0
+//    var tintColor = Color.bitcoinOrange
+//    var disabledColor = Color.bitcoinNeutral4
+//
+//    func makeBody(configuration: Configuration) -> some View {
+//        configuration.label
+//            .padding()
+//            .frame(width: width, height: 46)
+//            .background(stateBackgroundColor().cornerRadius(cornerRadius))
+//            .foregroundColor(stateTextColor())
+//            .overlay(
+//                RoundedRectangle(cornerRadius: cornerRadius)
+//                    .stroke(stateBorderColor(configuration: configuration), lineWidth: 1.5)
+//                )
+//            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+//            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+//    }
+//    func stateBackgroundColor() -> Color {
+//        return colorScheme == .dark ? .bitcoinBlack : .bitcoinWhite
+//    }
+//    func stateBorderColor(configuration: Configuration) -> Color {
+//        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+//    }
+//    func stateTextColor() -> Color {
+//        return isEnabled ? tintColor : disabledColor
+//    }
+//}

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -20,7 +20,7 @@ public struct BitcoinFilled: ButtonStyle {
     let disabledTextColor = Color.bitcoinNeutral5
     
     public init(width: CGFloat = 315.0) {
-        self.width
+        self.width = width
     }
 
     public func makeBody(configuration: Configuration) -> some View {

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -10,6 +10,11 @@ import SwiftUI
 
 public let defaultButtonWidth = 315.0
 public let defaultButtonHeight = 48.0
+public let defaultCornerRadius = 5.0
+public let defaultTintColor = Color.bitcoinOrange
+public let defaultTextColor = Color.bitcoinWhite
+public let defaultDisabledFillColor = Color.bitcoinNeutral2
+public let defaultDisabledTextColor = Color.bitcoinNeutral5
 
 public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme
@@ -17,15 +22,20 @@ public struct BitcoinFilled: ButtonStyle {
     
     let width: CGFloat
     let height: CGFloat
-    let cornerRadius = 5.0
-    let tintColor = Color.bitcoinOrange
+    let cornerRadius: CGFloat
+    let tintColor: Color
     let textColor = Color.bitcoinWhite
-    let disabledColor = Color.bitcoinNeutral2
+    let disabledFillColor = Color.bitcoinNeutral2
     let disabledTextColor = Color.bitcoinNeutral5
     
-    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight) {
+    public init(width: CGFloat = defaultButtonWidth, height: CGFloat = defaultButtonHeight, cornerRadius: CGFloat = defaultCornerRadius, tintColor: Color = defaultTintColor, textColor: Color = defaultTextColor, disabledFilleColor: Color = defaultDisabledFillColor, disabledTextColor: Color = defaultDisabledTextColor) {
         self.width = width
         self.height = height
+        self.cornerRadius = cornerRadius
+        self.tintColor = tintColor
+        self.textColor = textColor
+        self.disabledColor = disabledFilleColor
+        self.disabledTextColor = disabledTextColor
     }
 
     public func makeBody(configuration: Configuration) -> some View {
@@ -40,7 +50,7 @@ public struct BitcoinFilled: ButtonStyle {
     }
 
     private func stateBackgroundColor(configuration: Configuration) -> Color {
-        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledColor
+        return isEnabled ? configuration.isPressed ? tintColor.opacity(0.8) : tintColor : disabledFillColor
     }
     
     private func stateTextColor() -> Color {

--- a/Sources/WalletUI/ButtonStyles.swift
+++ b/Sources/WalletUI/ButtonStyles.swift
@@ -8,8 +8,8 @@
 import Foundation
 import SwiftUI
 
-private let defaultButtonWidth = 315.0
-private let defaultButtonHeight = 48.0
+public let defaultButtonWidth = 315.0
+public let defaultButtonHeight = 48.0
 
 public struct BitcoinFilled: ButtonStyle {
     @Environment(\.colorScheme) private var colorScheme

--- a/Sources/WalletUI/TextStyles.swift
+++ b/Sources/WalletUI/TextStyles.swift
@@ -61,7 +61,7 @@ public struct BitcoinTitle5: ViewModifier {
 
 public struct BitcoinBody1: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 24, weight: .regular))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)

--- a/Sources/WalletUI/TextStyles.swift
+++ b/Sources/WalletUI/TextStyles.swift
@@ -16,7 +16,7 @@ public extension Text {
 
 public struct BitcoinTitle1: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 36, weight: .semibold))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -25,7 +25,7 @@ public struct BitcoinTitle1: ViewModifier {
 
 public struct BitcoinTitle2: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 28, weight: .semibold))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -34,7 +34,7 @@ public struct BitcoinTitle2: ViewModifier {
 
 public struct BitcoinTitle3: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 24, weight: .semibold))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -43,7 +43,7 @@ public struct BitcoinTitle3: ViewModifier {
 
 public struct BitcoinTitle4: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 21, weight: .semibold))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -52,7 +52,7 @@ public struct BitcoinTitle4: ViewModifier {
 
 public struct BitcoinTitle5: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 18, weight: .semibold))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -70,7 +70,7 @@ public struct BitcoinBody1: ViewModifier {
 
 public struct BitcoinBody2: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 21, weight: .regular))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -79,7 +79,7 @@ public struct BitcoinBody2: ViewModifier {
 
 public struct BitcoinBody3: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 18, weight: .regular))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -88,7 +88,7 @@ public struct BitcoinBody3: ViewModifier {
 
 public struct BitcoinBody4: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 15, weight: .regular))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
@@ -97,7 +97,7 @@ public struct BitcoinBody4: ViewModifier {
 
 public struct BitcoinBody5: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             .font(.system(size: 13, weight: .regular))
             .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)

--- a/Sources/WalletUI/TextStyles.swift
+++ b/Sources/WalletUI/TextStyles.swift
@@ -16,6 +16,7 @@ public extension Text {
 
 public struct BitcoinTitle1: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init(){}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 36, weight: .semibold))

--- a/Sources/WalletUI/TextStyles.swift
+++ b/Sources/WalletUI/TextStyles.swift
@@ -16,7 +16,7 @@ public extension Text {
 
 public struct BitcoinTitle1: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    public init(){}
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 36, weight: .semibold))
@@ -26,6 +26,7 @@ public struct BitcoinTitle1: ViewModifier {
 
 public struct BitcoinTitle2: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 28, weight: .semibold))
@@ -35,6 +36,7 @@ public struct BitcoinTitle2: ViewModifier {
 
 public struct BitcoinTitle3: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 24, weight: .semibold))
@@ -44,6 +46,7 @@ public struct BitcoinTitle3: ViewModifier {
 
 public struct BitcoinTitle4: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 21, weight: .semibold))
@@ -53,6 +56,7 @@ public struct BitcoinTitle4: ViewModifier {
 
 public struct BitcoinTitle5: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 18, weight: .semibold))
@@ -62,6 +66,7 @@ public struct BitcoinTitle5: ViewModifier {
 
 public struct BitcoinBody1: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 24, weight: .regular))
@@ -71,6 +76,7 @@ public struct BitcoinBody1: ViewModifier {
 
 public struct BitcoinBody2: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 21, weight: .regular))
@@ -80,6 +86,7 @@ public struct BitcoinBody2: ViewModifier {
 
 public struct BitcoinBody3: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 18, weight: .regular))
@@ -89,6 +96,7 @@ public struct BitcoinBody3: ViewModifier {
 
 public struct BitcoinBody4: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 15, weight: .regular))
@@ -98,6 +106,7 @@ public struct BitcoinBody4: ViewModifier {
 
 public struct BitcoinBody5: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
+    public init() {}
     public func body(content: Content) -> some View {
         content
             .font(.system(size: 13, weight: .regular))

--- a/Sources/WalletUI/TextStyles.swift
+++ b/Sources/WalletUI/TextStyles.swift
@@ -1,0 +1,106 @@
+//
+//  TextStyles.swift
+//  
+//
+//  Created by Daniel Nordh on 16/09/2022.
+//
+
+import Foundation
+import SwiftUI
+
+public extension Text {
+    func textStyle<Style: ViewModifier>(_ style: Style) -> some View {
+        ModifiedContent(content: self, modifier: style)
+    }
+}
+
+public struct BitcoinTitle1: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 36, weight: .semibold))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinTitle2: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 28, weight: .semibold))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinTitle3: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 24, weight: .semibold))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinTitle4: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 21, weight: .semibold))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinTitle5: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinBody1: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 24, weight: .regular))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinBody2: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 21, weight: .regular))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinBody3: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 18, weight: .regular))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinBody4: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 15, weight: .regular))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+
+public struct BitcoinBody5: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: 13, weight: .regular))
+            .foregroundColor(colorScheme == .dark ? .bitcoinWhite : .bitcoinBlack)
+    }
+}
+


### PR DESCRIPTION
This PR adds ButtonStyles and TextStyles.

ButtonStyles implements the Filled, Outlined and Plain styles from the guide with optional parameters for customisation.

TextStyles implements Title 1-5 and Body 1-5 from the guide.

Basic mentions and examples added to the readme.