### PR TITLE
feat: improve bitcoinui skill descriptions (61% → 100%)

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/site/skills/bitcoinui/SKILL.md
+++ b/site/skills/bitcoinui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bitcoinui
-description: Bitcoin UI review (iOS)
+description: "Reviews iOS SwiftUI code for Bitcoin-specific UX correctness, accessibility, and iOS HIG alignment. Checks addresses, QR codes, seed phrases, fees, and units against the Bitcoin Design Guide and suggests BitcoinUI components. Use when reviewing Bitcoin wallet iOS screens, auditing SwiftUI views for Bitcoin UX issues, or checking mobile Bitcoin app interfaces for accessibility and design consistency."
 ---
 
 # BitcoinUI Review

--- a/skills/bitcoinui/SKILL.md
+++ b/skills/bitcoinui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bitcoinui
-description: Bitcoin UI review (iOS)
+description: "Reviews iOS SwiftUI code for Bitcoin-specific UX correctness, accessibility, and iOS HIG alignment. Checks addresses, QR codes, seed phrases, fees, and units against the Bitcoin Design Guide and suggests BitcoinUI components. Use when reviewing Bitcoin wallet iOS screens, auditing SwiftUI views for Bitcoin UX issues, or checking mobile Bitcoin app interfaces for accessibility and design consistency."
 ---
 
 # BitcoinUI Review


### PR DESCRIPTION
Hey @reez 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="682" alt="image" src="https://github.com/user-attachments/assets/6f0928b5-79ef-4127-a311-b49c9ab6bf6c" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| `skills/bitcoinui` | 61% | 100% | +39% |
| `site/skills/bitcoinui` | 61% | 100% | +39% |

<details>
<summary>What changed</summary>

Both `SKILL.md` files (in `skills/` and `site/skills/`) had identical content that already scored 100% on content quality — the review workflow, output format, and rubric references are excellent. The only gap was the frontmatter `description` field (scoring 22%), which was too terse for agent tool-selection to work well.

**Changes made:**
- Expanded the `description` field with specific actions the skill performs (reviews SwiftUI code, checks addresses/QR/seeds/fees/units)
- Added natural trigger terms (`Bitcoin wallet`, `iOS screens`, `SwiftUI views`, `Bitcoin UX`, `mobile Bitcoin app`)
- Added an explicit `Use when...` clause covering three distinct trigger scenarios
- Formatted description as a quoted string per frontmatter best practices
- No changes to skill body or references — they were already top-notch

</details>

## Automated Skill Review Workflow

This PR also adds `.github/workflows/skill-review.yml` so future PRs that touch `SKILL.md` get automatic feedback:

- **What runs:** on PRs that change `**/SKILL.md`, [`tesslio/skill-review`](https://github.com/tesslio/skill-review) posts one comment with Tessl scores and suggestions (updated on each push)
- **Zero extra accounts:** contributors don't need a Tessl login — only the default `GITHUB_TOKEN` is used
- **Non-blocking by default:** feedback-only, no surprise red CI
- **Not a build replacement:** this just reviews skill markdown — it doesn't touch your Swift build or format pipelines
- **Optional gate:** add `with: fail-threshold: 70` later if you want PRs to fail on low scores
- **Why only two skills edited here:** this PR stays small and reviewable — after merge, every future PR that touches a `SKILL.md` gets automatic review comments, so improvements can happen incrementally

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
